### PR TITLE
Force set default

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -915,6 +915,10 @@ class FontProperties:
 
 
 class _JSONEncoder(json.JSONEncoder):
+    def __init__(self, *args, **kwargs):
+        kwargs["default"] = self.default
+        super.__init__(*args, **kwargs)
+
     def default(self, o):
         if isinstance(o, FontManager):
             return dict(o.__dict__, __class__='FontManager')

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -917,7 +917,7 @@ class FontProperties:
 class _JSONEncoder(json.JSONEncoder):
     def __init__(self, *args, **kwargs):
         kwargs["default"] = self.default
-        super.__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def default(self, o):
         if isinstance(o, FontManager):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
With a "fresh" install I was getting

```
    import matplotlib.pyplot as plt  # noqa: E402 pylint: disable=wrong-import-position
/home/developer/.local/lib/python3.9/site-packages/matplotlib/pyplot.py:55: in <module>
    import matplotlib.colorbar
/home/developer/.local/lib/python3.9/site-packages/matplotlib/colorbar.py:19: in <module>
    from matplotlib import _api, cbook, collections, cm, colors, contour, ticker
/home/developer/.local/lib/python3.9/site-packages/matplotlib/contour.py:15: in <module>
    from matplotlib.backend_bases import MouseButton
/home/developer/.local/lib/python3.9/site-packages/matplotlib/backend_bases.py:49: in <module>
    from matplotlib import (
/home/developer/.local/lib/python3.9/site-packages/matplotlib/text.py:16: in <module>
    from .font_manager import FontProperties
/home/developer/.local/lib/python3.9/site-packages/matplotlib/font_manager.py:1588: in <module>
    fontManager = _load_fontmanager()
/home/developer/.local/lib/python3.9/site-packages/matplotlib/font_manager.py:1583: in _load_fontmanager
    json_dump(fm, fm_path)
/home/developer/.local/lib/python3.9/site-packages/matplotlib/font_manager.py:970: in json_dump
    json.dump(data, fh, cls=_JSONEncoder, indent=2)
/home/developer/.local/lib/python3.9/site-packages/json_numpy.py:54: in dump
    return _dump(*args, **kwargs)
/usr/local/lib/python3.9/json/__init__.py:179: in dump
    for chunk in iterable:
/usr/local/lib/python3.9/json/encoder.py:438: in _iterencode
    o = _default(o)
/home/developer/.local/lib/python3.9/site-packages/json_numpy.py:24: in default
    raise TypeError(msg)
E   TypeError: Object of type <class 'matplotlib.font_manager.FontManager'> is not JSON serializable
```

Herewith that is fixed


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
